### PR TITLE
Update gh-pages.yml

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,8 +40,12 @@ jobs:
       - name: Build Library and static website
         run: pnpm run publish
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          # Upload entire repository
+          path: ./dist
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1
+ 

--- a/wiki/tiddlers/test.tid
+++ b/wiki/tiddlers/test.tid
@@ -1,8 +1,0 @@
-created: 20230218072320640
-creator: 林一二
-modified: 20230601115351731
-modifier: 林一二
-title: test
-type: text/vnd.tiddlywiki
-
-test

--- a/wiki/tiddlers/test.tid
+++ b/wiki/tiddlers/test.tid
@@ -1,0 +1,8 @@
+created: 20230218072320640
+creator: 林一二
+modified: 20230601115351731
+modifier: 林一二
+title: test
+type: text/vnd.tiddlywiki
+
+test


### PR DESCRIPTION
应该是这个文件出了问题，导致一直发布不了。我刚试了我自己本地也发布不了网址才发现的。现在更新了一下，我这边仓库是可以发布网址了。你合并之后重新运行actions，应该能看到更新的内容。